### PR TITLE
fix: add defaults to jelly template instead of class

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,5 +17,8 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
+    - name: Formatting
+      run: mvn spotless:check
+
     - name: Build with Maven
       run: mvn package

--- a/src/main/java/com/nowsecure/models/LogLevel.java
+++ b/src/main/java/com/nowsecure/models/LogLevel.java
@@ -15,5 +15,4 @@ public enum LogLevel {
     public String getDescription() {
         return description;
     }
-
 }

--- a/src/main/java/com/nowsecure/plugin/NowSecurePlugin.java
+++ b/src/main/java/com/nowsecure/plugin/NowSecurePlugin.java
@@ -8,7 +8,6 @@ import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.nowsecure.models.AnalysisType;
 import com.nowsecure.models.LogLevel;
 import com.nowsecure.models.NowSecureBinary;
-
 import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -30,7 +29,6 @@ import java.util.Collections;
 import java.util.Optional;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
-import org.kohsuke.stapler.verb.POST;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
@@ -38,6 +36,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 public class NowSecurePlugin extends Builder implements SimpleBuildStep {
     // Required
@@ -48,16 +47,16 @@ public class NowSecurePlugin extends Builder implements SimpleBuildStep {
     // https://github.com/jenkinsci/credentials-plugin/blob/master/docs/consumer.adoc
     private final String tokenCredentialId;
 
-    private String artifactDir = "nowsecure";
-    private String apiHost = "https://lab-api.nowsecure.com";
-    private String uiHost = "https://app.nowsecure.com";
+    private String artifactDir;
+    private String apiHost;
+    private String uiHost;
     private String nowsecureCIVersion;
 
     private LogLevel logLevel = LogLevel.INFO;
     private AnalysisType analysisType = AnalysisType.STATIC;
 
-    private int minimumScore = -1;
-    private int pollingDurationMinutes = 20;
+    private int minimumScore;
+    private int pollingDurationMinutes;
 
     @DataBoundConstructor
     public NowSecurePlugin(String binaryFilePath, String group, String tokenCredentialId) {
@@ -192,7 +191,6 @@ public class NowSecurePlugin extends Builder implements SimpleBuildStep {
             return FormValidation.ok();
         }
 
-
         @POST // Has to be of the form 'doFill<FieldName>Items'
         public ListBoxModel doFillTokenCredentialIdItems(
                 @AncestorInPath Item item, @QueryParameter String tokenCredentialId) {
@@ -266,48 +264,47 @@ public class NowSecurePlugin extends Builder implements SimpleBuildStep {
         this.pollingDurationMinutes = pollingDurationMinutes;
     }
 
-	public String getBinaryFilePath() {
-		return binaryFilePath;
-	}
+    public String getBinaryFilePath() {
+        return binaryFilePath;
+    }
 
-	public String getGroup() {
-		return group;
-	}
+    public String getGroup() {
+        return group;
+    }
 
-	public String getTokenCredentialId() {
-		return tokenCredentialId;
-	}
+    public String getTokenCredentialId() {
+        return tokenCredentialId;
+    }
 
-	public String getArtifactDir() {
-		return artifactDir;
-	}
+    public String getArtifactDir() {
+        return artifactDir;
+    }
 
-	public String getApiHost() {
-		return apiHost;
-	}
+    public String getApiHost() {
+        return apiHost;
+    }
 
-	public String getUiHost() {
-		return uiHost;
-	}
+    public String getUiHost() {
+        return uiHost;
+    }
 
-	public String getNowsecureCIVersion() {
-		return nowsecureCIVersion;
-	}
+    public String getNowsecureCIVersion() {
+        return nowsecureCIVersion;
+    }
 
-	public LogLevel getLogLevel() {
-		return logLevel;
-	}
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
 
-	public AnalysisType getAnalysisType() {
-		return analysisType;
-	}
+    public AnalysisType getAnalysisType() {
+        return analysisType;
+    }
 
-	public int getMinimumScore() {
-		return minimumScore;
-	}
+    public int getMinimumScore() {
+        return minimumScore;
+    }
 
-	public int getPollingDurationMinutes() {
-		return pollingDurationMinutes;
-	}
-
+    public int getPollingDurationMinutes() {
+        return pollingDurationMinutes;
+    }
 }

--- a/src/main/resources/com/nowsecure/plugin/NowSecurePlugin/config.jelly
+++ b/src/main/resources/com/nowsecure/plugin/NowSecurePlugin/config.jelly
@@ -13,19 +13,19 @@
     </f:entry>
     <f:advanced>
         <f:entry title="Artifact Directory" field="artifactDir" description="${%ArtifactDirDesc}">
-            <f:textbox />
+            <f:textbox default="nowsecure"/>
         </f:entry>
         <f:entry title="API Host" field="apiHost" description="${%APIHostDesc}">
-            <f:textbox />
+            <f:textbox default="https://lab-api.nowsecure.com" />
         </f:entry>
         <f:entry title="UI Host" field="uiHost" description="${%UIHostDesc}">
-            <f:textbox />
+            <f:textbox default="https://app.nowsecure.com" />
         </f:entry>
         <f:entry title="Minimum Score" field="minimumScore" description="${%MinimumScoreDesc}">
-            <f:textbox />
+            <f:number min="0" max="100" default="0"/>
         </f:entry>
         <f:entry title="${%Polling Duration (Minutes)}" field="pollingDurationMinutes" description="${%PollingDurationDesc}">
-            <f:textbox />
+            <f:number min="0" default="20"/>
         </f:entry>
         <f:entry title="${%Log Level}" field="logLevel" description="${%LogLevelDesc}">
             <f:enum default="INFO">

--- a/src/test/java/com/nowsecure/plugin/NowSecurePluginTest.java
+++ b/src/test/java/com/nowsecure/plugin/NowSecurePluginTest.java
@@ -8,7 +8,6 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.nowsecure.models.AnalysisType;
 import com.nowsecure.models.LogLevel;
-
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.util.FormValidation;


### PR DESCRIPTION
### Type of Change

Please check the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Other (please describe):

### Description
- Previously, form controls weren't displaying the default values
- Default values are specified in the jelly template file itself instead of in the plugin class.
- A formatting check has also been added to avoid needlessly large diffs in case I forget to run spotless before committing 